### PR TITLE
fix: use native claude plugins install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+
+### Fixed
+- Replace `npx skillsadd` install command with native `claude plugins marketplace add` / `claude plugins install` commands (closes #1)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Claude Code skills for bootstrapping and demoing Ansible Automation Platform (AA
 ## Install
 
 ```bash
-npx skillsadd ericcames/aap-skills
+claude plugins marketplace add ericcames/aap-skills
+claude plugins install aap-skills
 ```
 
 ## Prerequisites


### PR DESCRIPTION
## Summary

- Replaces `npx skillsadd ericcames/aap-skills` with the Claude Code native `claude plugins marketplace add` / `claude plugins install` commands
- Adds `CHANGELOG.md` to track future changes
- Closes #1

## Test plan

- [x] Run `claude plugins marketplace add ericcames/aap-skills` — should add the marketplace without error
- [x] Run `claude plugins install aap-skills` — should install both skills
- [x] Confirm `/aap-bootstrap` and `/aap-setup-demo` are available in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)