### PR TITLE
feat: add preflight check to /aap-bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - New `/aap-first-time` skill for first-time local prerequisite setup — walks through ansible.cfg, secrets2, collections, SSH key pair, and vault file interactively (closes #3)
 
+### Changed
+- `/aap-bootstrap` now runs a preflight check before starting — fails fast with a clear message and directs user to `/aap-first-time` if ansible.cfg, secrets2, or collections are missing (closes #5)
+
 ## [1.0.1] - 2026-04-23
 
 ### Fixed

--- a/skills/aap-bootstrap/SKILL.md
+++ b/skills/aap-bootstrap/SKILL.md
@@ -18,6 +18,37 @@ A bootstrap provisions these objects on a fresh AAP instance:
 
 When bootstrap completes the AAP instance is ready but no demo has been configured yet. To configure the demo, run `/aap-setup-demo`.
 
+## Preflight Check
+
+Before doing anything else, verify all local prerequisites are in place:
+
+```bash
+# ansible.cfg with Hub token
+grep -q "galaxy_server.rh_certified" ~/.ansible/ansible.cfg 2>/dev/null && \
+  grep -v "PASTE_YOUR_TOKEN_HERE" ~/.ansible/ansible.cfg | grep -q "token=" && \
+  echo "✅ ansible.cfg" || echo "❌ ansible.cfg"
+
+# secrets2
+test -s ~/.ansible/secrets2 && echo "✅ secrets2" || echo "❌ secrets2"
+
+# collections
+test -d ./collections/ansible_collections/ansible/platform && \
+  echo "✅ ansible.platform" || echo "❌ ansible.platform"
+
+test -d ./collections/ansible_collections/ansible/controller && \
+  echo "✅ ansible.controller" || echo "❌ ansible.controller"
+```
+
+If any check fails, stop immediately and tell the user:
+
+```
+❌ Prerequisites missing: <list each failing item>
+
+Run /aap-first-time to set up these prerequisites before bootstrapping.
+```
+
+Do not proceed to Step 1 until all checks pass.
+
 ## Step 1 — Identify the Environment
 
 Ask the user for two values to name the inventory:


### PR DESCRIPTION
## Summary

Adds an explicit preflight check before Step 1 of `/aap-bootstrap`. If any local prerequisite is missing, the skill stops immediately with a clear message and directs the user to `/aap-first-time`.

- Closes #5

## Checks added

- `~/.ansible/ansible.cfg` exists and contains `[galaxy_server.rh_certified]` with a non-placeholder token
- `~/.ansible/secrets2` exists and is non-empty
- `ansible.platform` collection present in `./collections`
- `ansible.controller` collection present in `./collections`

## Test plan

- [ ] Run `/aap-bootstrap` with all prerequisites in place — should pass preflight and proceed to Step 1
- [ ] Run `/aap-bootstrap` with `~/.ansible/ansible.cfg` missing — should report ❌ and stop with message to run `/aap-first-time`
- [ ] Run `/aap-bootstrap` with `token=PASTE_YOUR_TOKEN_HERE` placeholder in ansible.cfg — should report ❌ and stop
- [ ] Run `/aap-bootstrap` with `~/.ansible/secrets2` missing — should report ❌ and stop
- [ ] Run `/aap-bootstrap` with collections missing — should report ❌ and stop
- [ ] Run `/aap-bootstrap` with multiple items missing — should list all failing items before stopping

🤖 Generated with [Claude Code](https://claude.com/claude-code)