### PR TITLE
feat: add preflight checks to /aap-setup-demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - `/aap-bootstrap` now runs a preflight check before starting — fails fast with a clear message and directs user to `/aap-first-time` if ansible.cfg, secrets2, or collections are missing (closes #5)
+- `/aap-setup-demo` now checks local prerequisites before starting — fails fast with a clear message and directs user to `/aap-first-time` if ansible.cfg, secrets2, or collections are missing (closes #7)
+- `/aap-setup-demo` now checks if AAP is already bootstrapped before running bootstrap steps — skips straight to job launch if project and job template already exist (closes #7)
 
 ## [1.0.1] - 2026-04-23
 

--- a/skills/aap-setup-demo/SKILL.md
+++ b/skills/aap-setup-demo/SKILL.md
@@ -12,9 +12,60 @@ This skill bootstraps a fresh Ansible Automation Platform instance and then laun
 This skill extends `/aap-bootstrap` with one additional step: after bootstrap completes it launches `Setup - AAP - CAC` in AAP and monitors the job until completion.
 
 The full sequence:
-1. Bootstrap AAP (Hub creds, Vault cred, project, job template)
-2. Launch `Setup - AAP - CAC` from AAP
-3. Monitor and report job status
+1. Preflight — verify local prerequisites and check AAP bootstrap state
+2. Bootstrap AAP if needed (Hub creds, Vault cred, project, job template)
+3. Launch `Setup - AAP - CAC` from AAP
+4. Monitor and report job status
+
+## Preflight Check — Part 1: Local Prerequisites
+
+Before doing anything else, verify local prerequisites are in place:
+
+```bash
+# ansible.cfg with Hub token
+grep -q "galaxy_server.rh_certified" ~/.ansible/ansible.cfg 2>/dev/null && \
+  grep -v "PASTE_YOUR_TOKEN_HERE" ~/.ansible/ansible.cfg | grep -q "token=" && \
+  echo "✅ ansible.cfg" || echo "❌ ansible.cfg"
+
+# secrets2
+test -s ~/.ansible/secrets2 && echo "✅ secrets2" || echo "❌ secrets2"
+
+# collections
+test -d ./collections/ansible_collections/ansible/platform && \
+  echo "✅ ansible.platform" || echo "❌ ansible.platform"
+
+test -d ./collections/ansible_collections/ansible/controller && \
+  echo "✅ ansible.controller" || echo "❌ ansible.controller"
+```
+
+If any check fails, stop immediately:
+
+```
+❌ Prerequisites missing: <list each failing item>
+
+Run /aap-first-time to set up these prerequisites before continuing.
+```
+
+## Preflight Check — Part 2: AAP Bootstrap State
+
+Resolve AAP credentials using the same priority order as `/aap-bootstrap` (env vars → ansible.cfg → prompt). Then check whether AAP has already been bootstrapped:
+
+```bash
+# Check for project
+PROJECT_COUNT=$(curl -s -k \
+  -u admin:$CONTROLLER_PASSWORD \
+  "$CONTROLLER_HOST/api/controller/v2/projects/?name=aap.as.code" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['count'])")
+
+# Check for job template
+JT_COUNT=$(curl -s -k \
+  -u admin:$CONTROLLER_PASSWORD \
+  "$CONTROLLER_HOST/api/controller/v2/job_templates/?name=Setup+-+AAP+-+CAC" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['count'])")
+```
+
+- If both exist (`PROJECT_COUNT >= 1` and `JT_COUNT >= 1`): tell the user "AAP is already bootstrapped — skipping to job launch" and jump directly to Step 7.
+- If either is missing: proceed through Steps 1–6 to run the bootstrap first.
 
 ## AAP API Paths (2.5+)
 


### PR DESCRIPTION
## Summary

Adds two preflight checks to `/aap-setup-demo` before any work begins. Also brings CHANGELOG to full Keep a Changelog format with versioned releases.

- Closes #7

## What changed

**Part 1 — Local prerequisites** (runs before anything else, no credentials needed)
- Same check as `/aap-bootstrap`: ansible.cfg with Hub token, secrets2, collections
- If anything is missing: stop and direct user to `/aap-first-time`

**Part 2 — AAP bootstrap state** (runs after credential resolution)
- Queries AAP API to check if project `aap.as.code` and job template `Setup - AAP - CAC` already exist
- If both exist: skip bootstrap entirely, jump straight to Step 7 (job launch)
- If either is missing: run bootstrap steps first

## Test plan

**Local prerequisites**
- [ ] Run `/aap-setup-demo` with `~/.ansible/ansible.cfg` missing — should report ❌ and stop with message to run `/aap-first-time`
- [ ] Run `/aap-setup-demo` with `token=PASTE_YOUR_TOKEN_HERE` placeholder — should report ❌ and stop
- [ ] Run `/aap-setup-demo` with `~/.ansible/secrets2` missing — should report ❌ and stop
- [ ] Run `/aap-setup-demo` with collections missing — should report ❌ and stop

**AAP bootstrap state**
- [ ] Run `/aap-setup-demo` on a fresh AAP instance (no project/template) — should run full bootstrap then launch job
- [ ] Run `/aap-setup-demo` on an already-bootstrapped AAP instance — should report "AAP is already bootstrapped" and skip straight to job launch
- [ ] Run `/aap-setup-demo` where project exists but job template does not — should run bootstrap steps

**Happy path**
- [ ] Run `/aap-setup-demo` end-to-end on a fresh RHDP instance — all prerequisites present, bootstrap runs, job launches successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)