### PR TITLE
feat: add success summary to /aap-bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - `/aap-bootstrap` now runs a preflight check before starting — fails fast with a clear message and directs user to `/aap-first-time` if ansible.cfg, secrets2, or collections are missing (closes #5)
+- `/aap-bootstrap` Step 6 now verifies each created AAP object via API and prints a structured success summary; vault credential verified by type so any name is supported (closes #9)
 - `/aap-setup-demo` now checks local prerequisites before starting — fails fast with a clear message and directs user to `/aap-first-time` if ansible.cfg, secrets2, or collections are missing (closes #7)
 - `/aap-setup-demo` now checks if AAP is already bootstrapped before running bootstrap steps — skips straight to job launch if project and job template already exist (closes #7)
 

--- a/skills/aap-bootstrap/SKILL.md
+++ b/skills/aap-bootstrap/SKILL.md
@@ -147,11 +147,99 @@ Show the command to the user before running it and ask for confirmation.
 
 ## Step 6 — Report Results
 
-On success:
-- Confirm which AAP objects were created
-- Tell the user AAP is ready
-- Prompt: "Run `/aap-setup-demo` to load demo configuration into AAP"
+### On success
 
-On failure:
+Query the AAP API to verify each object was actually created, then print a structured summary.
+
+Create a session token for the verification queries:
+```bash
+TOKEN=$(curl -s -k -X POST \
+  -H "Content-Type: application/json" \
+  -u admin:$CONTROLLER_PASSWORD \
+  "$CONTROLLER_HOST/api/gateway/v1/tokens/" \
+  -d '{"description":"bootstrap-verify token","scope":"write"}' \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['token'])")
+
+TOKEN_ID=$(curl -s -k -X POST \
+  -H "Content-Type: application/json" \
+  -u admin:$CONTROLLER_PASSWORD \
+  "$CONTROLLER_HOST/api/gateway/v1/tokens/" \
+  -d '{"description":"bootstrap-verify token","scope":"write"}' \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'])")
+```
+
+Verify each object and print status:
+```bash
+# Automation Hub - certified
+curl -s -k -H "Authorization: Bearer $TOKEN" \
+  "$CONTROLLER_HOST/api/controller/v2/credentials/?name=Automation+Hub+-+certified" \
+  | python3 -c "import sys,json; c=json.load(sys.stdin)['count']; print('✅ Automation Hub - certified' if c>0 else '❌ Automation Hub - certified — NOT FOUND')"
+
+# Automation Hub - validated
+curl -s -k -H "Authorization: Bearer $TOKEN" \
+  "$CONTROLLER_HOST/api/controller/v2/credentials/?name=Automation+Hub+-+validated" \
+  | python3 -c "import sys,json; c=json.load(sys.stdin)['count']; print('✅ Automation Hub - validated' if c>0 else '❌ Automation Hub - validated — NOT FOUND')"
+
+# Vault credential — query by type, display actual name
+curl -s -k -H "Authorization: Bearer $TOKEN" \
+  "$CONTROLLER_HOST/api/controller/v2/credentials/?kind=vault" \
+  | python3 -c "
+import sys,json
+results=json.load(sys.stdin)['results']
+if results:
+    for r in results:
+        print(f'✅ {r[\"name\"]} (vault)')
+else:
+    print('❌ Vault credential — NOT FOUND')"
+
+# Project — also check sync status
+curl -s -k -H "Authorization: Bearer $TOKEN" \
+  "$CONTROLLER_HOST/api/controller/v2/projects/?name=aap.as.code" \
+  | python3 -c "
+import sys,json
+results=json.load(sys.stdin)['results']
+if results:
+    status=results[0]['status']
+    icon='✅' if status=='successful' else '⚠️'
+    print(f'{icon} aap.as.code (sync: {status})')
+else:
+    print('❌ aap.as.code — NOT FOUND')"
+
+# Job template
+curl -s -k -H "Authorization: Bearer $TOKEN" \
+  "$CONTROLLER_HOST/api/controller/v2/job_templates/?name=Setup+-+AAP+-+CAC" \
+  | python3 -c "import sys,json; c=json.load(sys.stdin)['count']; print('✅ Setup - AAP - CAC' if c>0 else '❌ Setup - AAP - CAC — NOT FOUND')"
+```
+
+Delete the verification token:
+```bash
+curl -s -k -X DELETE \
+  -H "Authorization: Bearer $TOKEN" \
+  "$CONTROLLER_HOST/api/gateway/v1/tokens/$TOKEN_ID/"
+```
+
+Print the final summary in this format:
+```
+Bootstrap complete. Created in AAP:
+
+  Credentials:
+    ✅ Automation Hub - certified
+    ✅ Automation Hub - validated
+    ✅ <vault credential name> (vault)
+
+  Projects:
+    ✅ aap.as.code (sync: successful)
+
+  Job Templates:
+    ✅ Setup - AAP - CAC
+
+Next step: Run /aap-setup-demo to configure your full demo environment,
+or launch "Setup - AAP - CAC" manually in the AAP UI.
+```
+
+If any object shows ❌, tell the user which object is missing and suggest re-running `/aap-bootstrap` to retry.
+
+### On failure
+
 - Show the error from the playbook output
 - Suggest the most likely fix based on the error message

--- a/skills/aap-bootstrap/SKILL.md
+++ b/skills/aap-bootstrap/SKILL.md
@@ -175,9 +175,13 @@ curl -s -k -H "Authorization: Bearer $TOKEN" \
   "$CONTROLLER_HOST/api/controller/v2/credentials/?name=Automation+Hub+-+validated" \
   | python3 -c "import sys,json; c=json.load(sys.stdin)['count']; print('✅ Automation Hub - validated' if c>0 else '❌ Automation Hub - validated — NOT FOUND')"
 
-# Vault credential — query by type, display actual name
+# Vault credential — look up the Vault credential type ID first, then query by it
+VAULT_TYPE_ID=$(curl -s -k -H "Authorization: Bearer $TOKEN" \
+  "$CONTROLLER_HOST/api/controller/v2/credential_types/?name=Vault" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['results'][0]['id'])")
+
 curl -s -k -H "Authorization: Bearer $TOKEN" \
-  "$CONTROLLER_HOST/api/controller/v2/credentials/?kind=vault" \
+  "$CONTROLLER_HOST/api/controller/v2/credentials/?credential_type=$VAULT_TYPE_ID" \
   | python3 -c "
 import sys,json
 results=json.load(sys.stdin)['results']

--- a/skills/aap-bootstrap/SKILL.md
+++ b/skills/aap-bootstrap/SKILL.md
@@ -153,19 +153,14 @@ Query the AAP API to verify each object was actually created, then print a struc
 
 Create a session token for the verification queries:
 ```bash
-TOKEN=$(curl -s -k -X POST \
+TOKEN_JSON=$(curl -s -k -X POST \
   -H "Content-Type: application/json" \
   -u admin:$CONTROLLER_PASSWORD \
   "$CONTROLLER_HOST/api/gateway/v1/tokens/" \
-  -d '{"description":"bootstrap-verify token","scope":"write"}' \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['token'])")
+  -d '{"description":"bootstrap-verify token","scope":"write"}')
 
-TOKEN_ID=$(curl -s -k -X POST \
-  -H "Content-Type: application/json" \
-  -u admin:$CONTROLLER_PASSWORD \
-  "$CONTROLLER_HOST/api/gateway/v1/tokens/" \
-  -d '{"description":"bootstrap-verify token","scope":"write"}' \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'])")
+TOKEN=$(echo $TOKEN_JSON | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+TOKEN_ID=$(echo $TOKEN_JSON | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
 ```
 
 Verify each object and print status:


### PR DESCRIPTION
## Summary

Replaces the vague "Confirm which AAP objects were created" in Step 6 with explicit API verification and a structured printed summary.

- Closes #9

## What changed

After the bootstrap playbook exits successfully, the skill:
1. Creates a short-lived verification token (single API call, both token and ID parsed from one response)
2. Queries each expected object by name (credentials, project, job template)
3. For the vault credential, looks up the Vault credential type ID first, then queries by it — so any credential name is supported
4. Checks the project sync status (not just existence)
5. Prints a green/red summary and deletes the verification token
6. If any object is missing, tells the user which one and suggests re-running `/aap-bootstrap`

## Test plan

- [x] Verification queries return correct ✅ status against live AAP instance
- [x] Vault credential displayed by actual name (`Eric Ames`) — not hardcoded
- [x] Project sync status appears in summary (`sync: successful`)
- [x] Token created once from a single API call, deleted after summary prints
- [x] Deleted `Setup - AAP - CAC` from AAP — verification correctly showed ❌ for that object only, all others remained ✅
- [x] Re-bootstrapped AAP — all objects restored, verification shows all ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)