### PR TITLE
docs: add first-time routing and workflow diagram to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - New `/aap-first-time` skill for first-time local prerequisite setup
-- `skills/references/aap-as-code-context.md` — shared reference file with AAP object names, API endpoints, vault URL patterns, and full vault variable table (closes #15) — walks through ansible.cfg, secrets2, collections, SSH key pair, and vault file interactively (closes #3)
+- `skills/references/aap-as-code-context.md`
+- README: "First time here?" section pointing to `/aap-first-time`, workflow diagram showing three user paths, updated repo structure (closes #17) — shared reference file with AAP object names, API endpoints, vault URL patterns, and full vault variable table (closes #15) — walks through ansible.cfg, secrets2, collections, SSH key pair, and vault file interactively (closes #3)
 
 ### Changed
 - `/aap-bootstrap` Step 5 now includes idempotency guidance — `ok` results mean an object already exists and is correct, not a warning; re-running after a partial failure is safe (closes #11)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Claude Code skills for bootstrapping and demoing Ansible Automation Platform (AAP) instances provisioned from the Red Hat Demo Platform (RHDP).
 
+## First time here?
+
+Run this first:
+
+```
+/aap-first-time
+```
+
+It walks you through every prerequisite interactively and validates each one before continuing. Takes about 10 minutes once.
+
+Already set up? Skip to [Install](#install).
+
 ## Skills
 
 | Skill | Command | Purpose |
@@ -9,6 +21,23 @@ Claude Code skills for bootstrapping and demoing Ansible Automation Platform (AA
 | aap-first-time | `/aap-first-time` | First-time local setup — walks through every prerequisite interactively and validates each one. Run this once on a new machine before using the other skills. |
 | aap-bootstrap | `/aap-bootstrap` | Bootstrap a fresh AAP instance — creates Hub credentials, Vault credential, project, and job template. Stops when AAP is ready. |
 | aap-setup-demo | `/aap-setup-demo` | Bootstrap AAP **and** run `Setup - AAP - CAC` as a live demo story for a customer. |
+
+## Workflow
+
+**New user (first time on this machine):**
+```
+/aap-first-time → /aap-bootstrap → /aap-setup-demo
+```
+
+**Returning user (AAP already bootstrapped):**
+```
+/aap-setup-demo
+```
+
+**Just need AAP ready, no demo:**
+```
+/aap-bootstrap
+```
 
 ## Install
 
@@ -18,6 +47,8 @@ claude plugins install aap-skills
 ```
 
 ## Prerequisites
+
+Run `/aap-first-time` to set these up interactively, or configure manually:
 
 - Red Hat Demo Platform (RHDP) AAP instance provisioned
 - `~/.ansible/ansible.cfg` with a valid Automation Hub API token under `[galaxy_server.rh_certified]`
@@ -34,10 +65,14 @@ ANSIBLE_CONFIG=~/.ansible/ansible.cfg \
 
 ```
 skills/
+  aap-first-time/
+    SKILL.md
   aap-bootstrap/
     SKILL.md
   aap-setup-demo/
     SKILL.md
+  references/
+    aap-as-code-context.md
 ```
 
 ## Related


### PR DESCRIPTION
## Summary

Makes the README useful for new users by adding a routing section at the top and a workflow diagram showing how the three skills relate.

- Closes #17

## What changed

- **"First time here?"** section added near the top — points directly to `/aap-first-time` with a one-line description
- **Workflow section** — three paths shown as simple command sequences:
  - New user: `/aap-first-time → /aap-bootstrap → /aap-setup-demo`
  - Returning user: `/aap-setup-demo`
  - Just need AAP ready: `/aap-bootstrap`
- **Prerequisites section** updated to mention `/aap-first-time` as the recommended setup path
- **Repo structure** updated to include `aap-first-time/` and `references/`

## Test plan

- [x] README renders correctly — sections in logical order, workflow paths clear
- [x] "First time here?" section links back to Install anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)