### PR TITLE
fix: require aap.as.code clone before running skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - New `/aap-first-time` skill for first-time local prerequisite setup
+
+### Fixed
+- `/aap-first-time` now checks that the user is running from inside the `aap.as.code` repo before proceeding — stops with a clear clone instruction if not (closes #19)
+- README "First time here?" section now includes cloning `aap.as.code` as step 0 (closes #19)
 - `skills/references/aap-as-code-context.md`
 - README: "First time here?" section pointing to `/aap-first-time`, workflow diagram showing three user paths, updated repo structure (closes #17) — shared reference file with AAP object names, API endpoints, vault URL patterns, and full vault variable table (closes #15) — walks through ansible.cfg, secrets2, collections, SSH key pair, and vault file interactively (closes #3)
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,23 @@ Claude Code skills for bootstrapping and demoing Ansible Automation Platform (AA
 
 ## First time here?
 
-Run this first:
+**Step 1 — Clone the aap.as.code repo and open it in Claude Code:**
+
+```bash
+git clone https://github.com/ericcames/aap.as.code.git
+cd aap.as.code
+claude .
+```
+
+The skills run playbooks from this repo and install collections into it — you must run them from inside this directory.
+
+**Step 2 — Install the skills** (see [Install](#install) below), then run:
 
 ```
 /aap-first-time
 ```
 
-It walks you through every prerequisite interactively and validates each one before continuing. Takes about 10 minutes once.
+It walks you through every remaining prerequisite interactively and validates each one before continuing. Takes about 10 minutes once.
 
 Already set up? Skip to [Install](#install).
 

--- a/skills/aap-first-time/SKILL.md
+++ b/skills/aap-first-time/SKILL.md
@@ -31,6 +31,25 @@ We'll set up:
 After this, you'll be ready to run /aap-bootstrap or /aap-setup-demo.
 ```
 
+Before proceeding, verify the user is running from inside the `aap.as.code` repo:
+
+```bash
+test -f playbooks/bootstrap_dev.yml && echo "✅ In aap.as.code directory" || echo "❌ Wrong directory"
+```
+
+If the check fails, stop and tell the user:
+
+```
+❌ You must run this skill from inside the aap.as.code repo.
+
+Clone it first:
+  git clone https://github.com/ericcames/aap.as.code.git
+  cd aap.as.code
+  claude .
+
+Then re-run /aap-first-time.
+```
+
 ## Step 1 — Check What Already Exists
 
 Before doing anything, audit current state:


### PR DESCRIPTION
## Summary

Closes the gap where a new user could install the skills and run `/aap-first-time` without having cloned `aap.as.code` first — causing immediate collection and playbook errors.

- Closes #19

## Changes

**`/aap-first-time` SKILL.md**
- Added directory check immediately after orientation: `test -f playbooks/bootstrap_dev.yml`
- If check fails: stops and prints clear clone instructions before doing anything else

**README.md**
- "First time here?" section now has two explicit steps:
  1. Clone `aap.as.code` and open in Claude Code
  2. Install skills and run `/aap-first-time`

## Test plan

- [ ] Run `/aap-first-time` from a non-`aap.as.code` directory — should print ❌ and clone instructions
- [ ] Run `/aap-first-time` from inside `aap.as.code` — should pass the check and proceed to prerequisites

🤖 Generated with [Claude Code](https://claude.com/claude-code)