### PR TITLE
feat: enable skill discovery on initial clone via .claude/skills symlinks

### DIFF
--- a/.claude/skills/aap-bootstrap
+++ b/.claude/skills/aap-bootstrap
@@ -1,0 +1,1 @@
+../../skills/aap-bootstrap

--- a/.claude/skills/aap-first-time
+++ b/.claude/skills/aap-first-time
@@ -1,0 +1,1 @@
+../../skills/aap-first-time

--- a/.claude/skills/aap-setup-demo
+++ b/.claude/skills/aap-setup-demo
@@ -1,0 +1,1 @@
+../../skills/aap-setup-demo


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/<name>` symlinks to `../../skills/<name>` so Claude Code's project-level skill discovery finds the three skills the moment someone runs `claude .` in a freshly cloned repo — no `claude plugins marketplace add / install` round-trip required.
- `marketplace.json` is unchanged, so the existing install-via-marketplace flow still works.

## Why
Currently: `git clone https://github.com/ericcames/aap-skills && cd aap-skills && claude .` yields a Claude Code session with **no** `/aap-first-time`, `/aap-bootstrap`, or `/aap-setup-demo` — the skills are only reachable through the plugin marketplace flow. That's a dead end for anyone who clones the repo to inspect, contribute, or test changes locally.

After this PR: the same clone exposes all three skills as slash commands immediately. `/aap-first-time` itself still enforces its own preflight (verifies the user is in the `aap.as.code` repo and redirects if not), so running it from the `aap-skills` clone fails loudly and correctly rather than silently doing the wrong thing.

## How
Git stores the three entries as symlinks (mode 120000), not as copies:

```
.claude/skills/aap-first-time -> ../../skills/aap-first-time
.claude/skills/aap-bootstrap  -> ../../skills/aap-bootstrap
.claude/skills/aap-setup-demo -> ../../skills/aap-setup-demo
```

Confirmed via official Claude Code docs:
- `.claude/skills/<name>/SKILL.md` is the canonical project-level skill path
- Claude Code follows symlinks under `.claude/skills/`
- Project-level skills and plugin-scoped skills don't collide (plugin skills live under a `plugin:skill` namespace), so users with the plugin also installed get both `/aap-first-time` and `/aap-skills:aap-first-time` with no conflict

## Notes for the reviewer
- Three-symlink change, +3 lines in git (each entry is a single-line symlink blob). Very easy to revert with `git rm .claude/skills/*`.
- `references/` is deliberately not linked — it's shared content, not a skill.
- Does not depend on or interact with #21 (the `CLAUDE.md` PR); the two can be merged, skipped, or reordered independently.
- On Windows + git without `core.symlinks=true`, symlinks would show up as plain text files. This is a common gotcha for symlink-based distributions; flagging for your awareness.

## Test plan
- [ ] `git clone` a fresh copy of the branch, `cd` in, open Claude Code → confirm `/aap-first-time`, `/aap-bootstrap`, `/aap-setup-demo` are listed
- [ ] Confirm `marketplace.json` path still works: `claude plugins marketplace add ericcames/aap-skills` → skills load (no regression)
- [ ] Confirm `/aap-first-time` preflight still refuses to run from outside `aap.as.code`