### PR TITLE
docs: fix drift between docs and skill behavior

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code skills for bootstrapping and demoing Ansible Automation Platform instances from RHDP",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## Unreleased
 
 ### Added
-- New `/aap-first-time` skill for first-time local prerequisite setup
-
-### Fixed
-- `/aap-first-time` now checks that the user is running from inside the `aap.as.code` repo before proceeding — stops with a clear clone instruction if not (closes #19)
-- README "First time here?" section now includes cloning `aap.as.code` as step 0 (closes #19)
-- `skills/references/aap-as-code-context.md`
-- README: "First time here?" section pointing to `/aap-first-time`, workflow diagram showing three user paths, updated repo structure (closes #17) — shared reference file with AAP object names, API endpoints, vault URL patterns, and full vault variable table (closes #15) — walks through ansible.cfg, secrets2, collections, SSH key pair, and vault file interactively (closes #3)
+- New `/aap-first-time` skill walks through ansible.cfg, secrets2, collections, SSH key pair, and vault file interactively (closes #3)
+- New shared reference file `skills/references/aap-as-code-context.md` with AAP object names, API endpoints, vault URL patterns, and full vault variable table (closes #15)
 
 ### Changed
 - `/aap-bootstrap` Step 5 now includes idempotency guidance — `ok` results mean an object already exists and is correct, not a warning; re-running after a partial failure is safe (closes #11)
@@ -21,6 +16,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `/aap-setup-demo` now asks for audience (Technical / Management / Mixed) before launching and provides a tailored narration track for each (closes #13)
 - `/aap-setup-demo` now checks local prerequisites before starting — fails fast with a clear message and directs user to `/aap-first-time` if ansible.cfg, secrets2, or collections are missing (closes #7)
 - `/aap-setup-demo` now checks if AAP is already bootstrapped before running bootstrap steps — skips straight to job launch if project and job template already exist (closes #7)
+- README: added "First time here?" section pointing to `/aap-first-time`, workflow diagram showing three user paths, updated repo structure (closes #17)
+
+### Fixed
+- `/aap-first-time` now checks that the user is running from inside the `aap.as.code` repo before proceeding — stops with a clear clone instruction if not (closes #19)
+- README "First time here?" section now includes cloning `aap.as.code` as step 0 (closes #19)
 
 ## [1.0.1] - 2026-04-23
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,14 @@ Run `/aap-first-time` to set these up interactively, or configure manually:
 - `~/.ansible/secrets2` containing your vault password (single line)
 - Collections installed locally:
 
-```bash
-ANSIBLE_CONFIG=~/.ansible/ansible.cfg \
-  ansible-galaxy collection install ansible.platform ansible.controller \
-  -p ./collections
-```
+  ```bash
+  ANSIBLE_CONFIG=~/.ansible/ansible.cfg \
+    ansible-galaxy collection install ansible.platform ansible.controller \
+    -p ./collections
+  ```
+
+- An RSA SSH key pair at `~/.ssh/id_rsa` with the public key hosted at a public HTTPS raw URL (AWS requires RSA)
+- A vault file hosted at a public HTTPS raw URL with the variables listed in [`skills/references/aap-as-code-context.md`](skills/references/aap-as-code-context.md)
 
 ## Repo Structure
 

--- a/skills/aap-bootstrap/SKILL.md
+++ b/skills/aap-bootstrap/SKILL.md
@@ -10,11 +10,12 @@ This skill bootstraps a fresh Ansible Automation Platform instance provisioned f
 ## Overview
 
 A bootstrap provisions these objects on a fresh AAP instance:
-- Automation Hub certified and validated credentials
-- Galaxy credentials associated with the Default Organization
+- `Automation Hub - certified` and `Automation Hub - validated` credentials (assigned to the Default Organization as its galaxy credentials)
 - Vault credential
 - `aap.as.code` project (synced from `main`)
 - `Setup - AAP - CAC` job template
+
+See [`skills/references/aap-as-code-context.md`](../references/aap-as-code-context.md) for the exact object names and API endpoints used.
 
 When bootstrap completes the AAP instance is ready but no demo has been configured yet. To configure the demo, run `/aap-setup-demo`.
 
@@ -167,7 +168,7 @@ Create a session token for the verification queries:
 ```bash
 TOKEN_JSON=$(curl -s -k -X POST \
   -H "Content-Type: application/json" \
-  -u admin:$CONTROLLER_PASSWORD \
+  -u $CONTROLLER_USERNAME:$CONTROLLER_PASSWORD \
   "$CONTROLLER_HOST/api/gateway/v1/tokens/" \
   -d '{"description":"bootstrap-verify token","scope":"write"}')
 

--- a/skills/aap-first-time/SKILL.md
+++ b/skills/aap-first-time/SKILL.md
@@ -288,20 +288,7 @@ Direct the user to create one:
 > "Copy the example vault from https://github.com/ericcames/sourcefiles/blob/main/vault_example.yml,
 > fill in your values, encrypt it with ansible-vault, and host it in a public GitHub repo at a raw URL."
 
-Key vault variables to fill in:
-
-| Key | Purpose |
-|-----|---------|
-| `default_passwd` | Team default password; also used by the F5 demo |
-| `redhat_username` | RH service account username |
-| `redhat_passwd` | RH service account password |
-| `ssh_priv_key` | Your laptop private key (gives access to what you build) |
-| `admin_password` | Admin password for network gear (F5, Palo Alto, Infoblox) |
-| `red_hat_auto_hub_token` | Automation Hub API token |
-| `ddw_username` / `ddw_password` | Windows server credentials |
-| `snow_url` / `snow_username` / `servicenow_passwd` | ServiceNow credentials |
-
-Full variable reference is in the [aap.as.code README](https://github.com/ericcames/aap.as.code#readme).
+Full vault variable reference (keys, purposes, and example file link) is in [`skills/references/aap-as-code-context.md`](../references/aap-as-code-context.md#vault-variable-reference).
 
 Once they have a URL, validate it as described above.
 

--- a/skills/aap-setup-demo/SKILL.md
+++ b/skills/aap-setup-demo/SKILL.md
@@ -53,13 +53,13 @@ Resolve AAP credentials using the same priority order as `/aap-bootstrap` (env v
 ```bash
 # Check for project
 PROJECT_COUNT=$(curl -s -k \
-  -u admin:$CONTROLLER_PASSWORD \
+  -u $CONTROLLER_USERNAME:$CONTROLLER_PASSWORD \
   "$CONTROLLER_HOST/api/controller/v2/projects/?name=aap.as.code" \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['count'])")
 
 # Check for job template
 JT_COUNT=$(curl -s -k \
-  -u admin:$CONTROLLER_PASSWORD \
+  -u $CONTROLLER_USERNAME:$CONTROLLER_PASSWORD \
   "$CONTROLLER_HOST/api/controller/v2/job_templates/?name=Setup+-+AAP+-+CAC" \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['count'])")
 ```
@@ -69,18 +69,13 @@ JT_COUNT=$(curl -s -k \
 
 ## AAP API Paths (2.5+)
 
-AAP 2.5+ uses a gateway architecture. Always use these base paths:
+AAP 2.5+ uses a gateway architecture. Full endpoint list is in [`skills/references/aap-as-code-context.md`](../references/aap-as-code-context.md#aap-api-endpoints-25). This skill uses:
 
 | Purpose | Base path |
 |---------|-----------|
 | Token create/delete | `$CONTROLLER_HOST/api/gateway/v1/tokens/` |
 | Job templates | `$CONTROLLER_HOST/api/controller/v2/job_templates/` |
 | Jobs | `$CONTROLLER_HOST/api/controller/v2/jobs/` |
-
-Verify the API layout first if unsure:
-```bash
-curl -s -k "$CONTROLLER_HOST/api/" | python3 -m json.tool
-```
 
 ## Steps 1–6: Bootstrap First
 
@@ -129,7 +124,7 @@ First, create a session token via the gateway:
 ```bash
 TOKEN_JSON=$(curl -s -k -X POST \
   -H "Content-Type: application/json" \
-  -u admin:$CONTROLLER_PASSWORD \
+  -u $CONTROLLER_USERNAME:$CONTROLLER_PASSWORD \
   "$CONTROLLER_HOST/api/gateway/v1/tokens/" \
   -d '{"description":"setup-demo token","scope":"write"}')
 


### PR DESCRIPTION
## Summary

Ran a documentation accuracy review and fixed seven places where docs had drifted from skill behavior. No skill logic changes — only documentation, version metadata, and shell snippets that were inconsistent with their own spec.

## Fixes

- **CHANGELOG**: split a malformed `Unreleased` bullet that mashed three changes (closes #17, #15, #3) into separate entries; moved feature adds from `Fixed` into `Added`/`Changed`
- **marketplace.json**: bumped `version` `1.0.0` → `1.0.1` to match the released version in CHANGELOG
- **README** `Prerequisites`: added SSH key pair and hosted vault file (`/aap-first-time` sets up 5 items; README only listed 3)
- **aap-bootstrap** `Overview`: reworded "Galaxy credentials associated with the Default Organization" to clarify it's an assignment of the Hub credentials, not a separate created object; added a citation to the reference file
- **aap-bootstrap & aap-setup-demo**: replaced hardcoded `-u admin:\$CONTROLLER_PASSWORD` (4 occurrences) with `-u \$CONTROLLER_USERNAME:\$CONTROLLER_PASSWORD` so verification/preflight curls honor a non-default username (the skills already support one via env vars)
- **aap-first-time** Step 6: replaced partial vault-variable table with a citation to `skills/references/aap-as-code-context.md` (which has the full table)
- **aap-setup-demo** `AAP API Paths`: cited the reference file instead of duplicating content

The shared reference file's preamble claims *"Skills cite this file rather than duplicating the information"* — now they actually do.

## Test plan

- [ ] CHANGELOG renders cleanly on GitHub (no orphan bullets, no mashed em-dashes)
- [ ] README Prerequisites list shows 5 items
- [ ] `grep 'admin:\$CONTROLLER_PASSWORD' skills/` returns nothing
- [ ] Links to `skills/references/aap-as-code-context.md` resolve from each SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)