### PR TITLE
feat: collect and propagate user-specific vars for Setup - AAP - CAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - README: "First time here?" section pointing to `/aap-first-time`, workflow diagram showing three user paths, updated repo structure (closes #17) — shared reference file with AAP object names, API endpoints, vault URL patterns, and full vault variable table (closes #15) — walks through ansible.cfg, secrets2, collections, SSH key pair, and vault file interactively (closes #3)
 
 ### Changed
+- `/aap-first-time` now collects `my_vault` and `my_windows_catalog_short_description` and writes all four user-specific vars to `inventories/rhdp-sample-demo/group_vars/all.yml` (closes #25)
+- `/aap-bootstrap` and `/aap-setup-demo` now check `inventories/rhdp-sample-demo/group_vars/all.yml` at startup and halt if `my_vault`, `my_remote_vault`, or `my_remote_ssh_pub_key` are empty (closes #25)
+- `/aap-bootstrap` Step 4 now reads user-specific vars from `rhdp-sample-demo/group_vars/all.yml` instead of hardcoding them (closes #25)
 - `/aap-bootstrap` Step 5 now includes idempotency guidance — `ok` results mean an object already exists and is correct, not a warning; re-running after a partial failure is safe (closes #11)
 - `/aap-bootstrap` now runs a preflight check before starting — fails fast with a clear message and directs user to `/aap-first-time` if ansible.cfg, secrets2, or collections are missing (closes #5)
 - `/aap-bootstrap` Step 6 now verifies each created AAP object via API and prints a structured success summary; vault credential verified by type so any name is supported (closes #9)

--- a/skills/aap-bootstrap/SKILL.md
+++ b/skills/aap-bootstrap/SKILL.md
@@ -37,6 +37,20 @@ test -d ./collections/ansible_collections/ansible/platform && \
 
 test -d ./collections/ansible_collections/ansible/controller && \
   echo "✅ ansible.controller" || echo "❌ ansible.controller"
+
+# all.yml user vars
+python3 -c "
+import yaml, sys
+try:
+    d = yaml.safe_load(open('inventories/rhdp-sample-demo/group_vars/all.yml'))
+    missing = [k for k in ['my_vault','my_remote_vault','my_remote_ssh_pub_key'] if not d.get(k,'')]
+    if missing:
+        print('❌ all.yml missing: ' + ', '.join(missing))
+    else:
+        print('✅ all.yml user vars')
+except FileNotFoundError:
+    print('❌ all.yml — inventories/rhdp-sample-demo/group_vars/all.yml not found')
+"
 ```
 
 If any check fails, stop immediately and tell the user:
@@ -102,6 +116,19 @@ Read from `~/.ansible/secrets2` (single line, trimmed). If not found, ask the us
 
 ## Step 4 — Generate the Inventory
 
+First, read the user-specific vars from `inventories/rhdp-sample-demo/group_vars/all.yml`:
+
+```bash
+python3 -c "
+import yaml
+d = yaml.safe_load(open('inventories/rhdp-sample-demo/group_vars/all.yml'))
+for k in ['my_vault','my_windows_catalog_short_description','my_remote_vault','my_remote_ssh_pub_key']:
+    print(k + '=' + d.get(k,''))
+"
+```
+
+Use those values when writing the generated `all.yml` below.
+
 Create the inventory directory and vars file:
 
 ```
@@ -129,9 +156,13 @@ aap_validate_certs: false
 hub_token: "{{ lookup('ini', 'token section=galaxy_server.rh_certified file=~/.ansible/ansible.cfg') }}"
 vault_password: "{{ lookup('ansible.builtin.file', '~/.ansible/secrets2') | trim }}"
 hub_auth_url: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
-my_remote_vault: "https://raw.githubusercontent.com/ericcames/sourcefiles/refs/heads/main/vault_ames.yml"
-my_remote_ssh_pub_key: "https://raw.githubusercontent.com/ericcames/sourcefiles/refs/heads/main/id_rsa.pub"
+my_vault: "<my_vault from rhdp-sample-demo all.yml>"
+my_windows_catalog_short_description: "<my_windows_catalog_short_description from rhdp-sample-demo all.yml>"
+my_remote_vault: "<my_remote_vault from rhdp-sample-demo all.yml>"
+my_remote_ssh_pub_key: "<my_remote_ssh_pub_key from rhdp-sample-demo all.yml>"
 ```
+
+Substitute the actual values read from `rhdp-sample-demo/group_vars/all.yml` — do not copy the placeholder text literally.
 
 Remind the user that `group_vars/all.yml` contains no secrets — all sensitive values are resolved at runtime via lookups.
 

--- a/skills/aap-first-time/SKILL.md
+++ b/skills/aap-first-time/SKILL.md
@@ -66,6 +66,18 @@ ls ./collections/ansible_collections/ansible/ 2>/dev/null || echo "MISSING"
 
 # SSH key
 test -f ~/.ssh/id_rsa && echo "EXISTS" || echo "MISSING"
+
+# all.yml user vars
+python3 -c "
+import yaml, sys
+try:
+    d = yaml.safe_load(open('inventories/rhdp-sample-demo/group_vars/all.yml'))
+    for k in ['my_vault','my_remote_vault','my_remote_ssh_pub_key','my_windows_catalog_short_description']:
+        v = d.get(k,'')
+        print(('EXISTS: ' if v else 'MISSING: ') + k + (': ' + v if v else ''))
+except FileNotFoundError:
+    print('MISSING: inventories/rhdp-sample-demo/group_vars/all.yml')
+"
 ```
 
 For each item found, validate it has the right content:
@@ -73,6 +85,7 @@ For each item found, validate it has the right content:
 - **secrets2**: must be non-empty
 - **collections**: must include both `platform` and `controller` subdirectories
 - **SSH key**: must be RSA format
+- **all.yml vars**: `my_vault`, `my_remote_vault`, `my_remote_ssh_pub_key` must be non-empty
 
 Skip any section below where the item already exists and is valid. Tell the user what was found before proceeding:
 
@@ -81,6 +94,7 @@ Skip any section below where the item already exists and is valid. Tell the user
 ✅ ~/.ansible/secrets2 — found, non-empty
 ❌ ansible.platform collection — MISSING
 ❌ ~/.ssh/id_rsa — MISSING
+❌ my_vault — MISSING
 ```
 
 ## Step 2 — ansible.cfg Setup
@@ -305,7 +319,76 @@ Full variable reference is in the [aap.as.code README](https://github.com/ericca
 
 Once they have a URL, validate it as described above.
 
-## Step 7 — Final Validation
+## Step 7 — User-Specific Vars
+
+Write the user's identity vars to `inventories/rhdp-sample-demo/group_vars/all.yml`. These are used by `/aap-bootstrap` and `/aap-setup-demo` so you don't have to re-enter them for each environment.
+
+Skip any var that already has a non-empty value in `all.yml` (identified in Step 1).
+
+### 7a. Vault credential name
+
+If `my_vault` is missing, ask:
+> "What name should your vault credential have in AAP? This is used as both the credential name and the `my_vault` extra var on your job template. (e.g. `Eric Ames`)"
+
+Write the value to `my_vault` in `all.yml`.
+
+### 7b. Windows catalog description
+
+If `my_windows_catalog_short_description` is missing, ask:
+> "What is your ServiceNow Windows catalog item short description? Press Enter to accept the default."
+> Default: `Ames AAP Windows AWS Daily Demo`
+
+Write the value (or default) to `my_windows_catalog_short_description` in `all.yml`.
+
+### 7c. Remote vault and SSH key URLs
+
+If `my_remote_vault` or `my_remote_ssh_pub_key` are missing in `all.yml`, write the URLs collected and validated in Steps 5 and 6 to `all.yml` now.
+
+### 7d. Write all.yml
+
+Use Python to update `inventories/rhdp-sample-demo/group_vars/all.yml` in place, preserving all other keys and comments:
+
+```bash
+python3 << 'EOF'
+import re
+
+path = 'inventories/rhdp-sample-demo/group_vars/all.yml'
+updates = {
+    'my_vault': '<value from 7a>',
+    'my_windows_catalog_short_description': '<value from 7b>',
+    'my_remote_vault': '<url from step 6>',
+    'my_remote_ssh_pub_key': '<url from step 5>',
+}
+
+with open(path) as f:
+    content = f.read()
+
+for key, value in updates.items():
+    # Replace existing key
+    pattern = rf'^({key}:\s*).*$'
+    replacement = f'{key}: "{value}"'
+    new_content, n = re.subn(pattern, replacement, content, flags=re.MULTILINE)
+    if n == 0:
+        # Append if key not present
+        new_content = content.rstrip('\n') + f'\n{key}: "{value}"\n'
+    content = new_content
+
+with open(path, 'w') as f:
+    f.write(content)
+
+print('✅ all.yml updated')
+EOF
+```
+
+After writing, confirm:
+```
+✅ my_vault: <value>
+✅ my_windows_catalog_short_description: <value>
+✅ my_remote_vault: <url>
+✅ my_remote_ssh_pub_key: <url>
+```
+
+## Step 8 — Final Validation
 
 Run a complete preflight check and print green/red status for every item:
 
@@ -336,10 +419,14 @@ test -f ~/.ssh/id_rsa && \
   echo "❌ ~/.ssh/id_rsa — MISSING"
 ```
 
-Also confirm the results from Steps 5 and 6:
+Also confirm the results from Steps 5–7:
 ```
 ✅ SSH key pair — local key matches hosted public key
 ✅ Vault URL — accessible, returns YAML
+✅ my_vault — set
+✅ my_remote_vault — set
+✅ my_remote_ssh_pub_key — set
+✅ my_windows_catalog_short_description — set
 ```
 
 If everything is green, print:

--- a/skills/aap-setup-demo/SKILL.md
+++ b/skills/aap-setup-demo/SKILL.md
@@ -36,6 +36,20 @@ test -d ./collections/ansible_collections/ansible/platform && \
 
 test -d ./collections/ansible_collections/ansible/controller && \
   echo "✅ ansible.controller" || echo "❌ ansible.controller"
+
+# all.yml user vars
+python3 -c "
+import yaml, sys
+try:
+    d = yaml.safe_load(open('inventories/rhdp-sample-demo/group_vars/all.yml'))
+    missing = [k for k in ['my_vault','my_remote_vault','my_remote_ssh_pub_key'] if not d.get(k,'')]
+    if missing:
+        print('❌ all.yml missing: ' + ', '.join(missing))
+    else:
+        print('✅ all.yml user vars')
+except FileNotFoundError:
+    print('❌ all.yml — inventories/rhdp-sample-demo/group_vars/all.yml not found')
+"
 ```
 
 If any check fails, stop immediately:


### PR DESCRIPTION
## Summary

Implements the aap-skills half of issue #25.

- `/aap-first-time`: adds Step 7 to collect `my_vault` (vault credential name) and `my_windows_catalog_short_description` from the user, then writes all four user vars (`my_vault`, `my_windows_catalog_short_description`, `my_remote_vault`, `my_remote_ssh_pub_key`) to `inventories/rhdp-sample-demo/group_vars/all.yml`; Step 1 now audits those vars; old Step 7 renumbered to Step 8
- `/aap-bootstrap`: preflight now reads `rhdp-sample-demo/group_vars/all.yml` and halts with a `/aap-first-time` redirect if `my_vault`, `my_remote_vault`, or `my_remote_ssh_pub_key` are empty; Step 4 now reads user vars from that file instead of hardcoding Eric's values
- `/aap-setup-demo`: Part 1 preflight includes the same `all.yml` check

The companion PR in `aap.as.code` adds `my_vault` and `my_windows_catalog_short_description` to the sample inventory and replaces hardcoded values in `bootstrap_dev.yml` with `{{ my_vault }}` and `{{ my_windows_catalog_short_description }}`.

## Test plan

- [ ] Run `/aap-first-time` on a fresh checkout — verify Step 7 prompts appear and `all.yml` is updated correctly
- [ ] Run `/aap-bootstrap` without completing `/aap-first-time` first — verify preflight halts with clear message
- [ ] Run `/aap-setup-demo` without completing `/aap-first-time` first — verify preflight halts with clear message
- [ ] Complete `/aap-first-time` then run `/aap-bootstrap` — verify generated inventory `all.yml` contains correct user var values

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)