### PR TITLE
feat: persist user identity vars in ~/.ansible/aap_defaults.yml

### DIFF
--- a/skills/aap-bootstrap/SKILL.md
+++ b/skills/aap-bootstrap/SKILL.md
@@ -39,18 +39,19 @@ test -d ./collections/ansible_collections/ansible/platform && \
 test -d ./collections/ansible_collections/ansible/controller && \
   echo "✅ ansible.controller" || echo "❌ ansible.controller"
 
-# all.yml user vars
+# user defaults
 python3 -c "
-import yaml, sys
+import yaml, os
+path = os.path.expanduser('~/.ansible/aap_defaults.yml')
 try:
-    d = yaml.safe_load(open('inventories/rhdp-sample-demo/group_vars/all.yml'))
+    d = yaml.safe_load(open(path)) or {}
     missing = [k for k in ['my_vault','my_remote_vault','my_remote_ssh_pub_key'] if not d.get(k,'')]
     if missing:
-        print('❌ all.yml missing: ' + ', '.join(missing))
+        print('❌ ~/.ansible/aap_defaults.yml missing: ' + ', '.join(missing))
     else:
-        print('✅ all.yml user vars')
+        print('✅ ~/.ansible/aap_defaults.yml — user defaults present')
 except FileNotFoundError:
-    print('❌ all.yml — inventories/rhdp-sample-demo/group_vars/all.yml not found')
+    print('❌ ~/.ansible/aap_defaults.yml — not found. Run /aap-first-time.')
 "
 ```
 
@@ -117,14 +118,14 @@ Read from `~/.ansible/secrets2` (single line, trimmed). If not found, ask the us
 
 ## Step 4 — Generate the Inventory
 
-First, read the user-specific vars from `inventories/rhdp-sample-demo/group_vars/all.yml`:
+First, read the user-specific vars from `~/.ansible/aap_defaults.yml`:
 
 ```bash
 python3 -c "
-import yaml
-d = yaml.safe_load(open('inventories/rhdp-sample-demo/group_vars/all.yml'))
+import yaml, os
+d = yaml.safe_load(open(os.path.expanduser('~/.ansible/aap_defaults.yml'))) or {}
 for k in ['my_vault','my_windows_catalog_short_description','my_remote_vault','my_remote_ssh_pub_key']:
-    print(k + '=' + d.get(k,''))
+    print(k + '=' + str(d.get(k,'')))
 "
 ```
 

--- a/skills/aap-first-time/SKILL.md
+++ b/skills/aap-first-time/SKILL.md
@@ -27,6 +27,7 @@ We'll set up:
   3. Required Ansible collections (ansible.platform, ansible.controller)
   4. Your SSH key pair (local key + public key hosted at a URL)
   5. Your vault file (secrets the demo uses at runtime)
+  6. Your identity defaults (~/.ansible/aap_defaults.yml)
 
 After this, you'll be ready to run /aap-bootstrap or /aap-setup-demo.
 ```
@@ -67,16 +68,17 @@ ls ./collections/ansible_collections/ansible/ 2>/dev/null || echo "MISSING"
 # SSH key
 test -f ~/.ssh/id_rsa && echo "EXISTS" || echo "MISSING"
 
-# all.yml user vars
+# user defaults
 python3 -c "
-import yaml, sys
+import yaml, os, sys
+path = os.path.expanduser('~/.ansible/aap_defaults.yml')
 try:
-    d = yaml.safe_load(open('inventories/rhdp-sample-demo/group_vars/all.yml'))
+    d = yaml.safe_load(open(path)) or {}
     for k in ['my_vault','my_remote_vault','my_remote_ssh_pub_key','my_windows_catalog_short_description']:
         v = d.get(k,'')
-        print(('EXISTS: ' if v else 'MISSING: ') + k + (': ' + v if v else ''))
+        print(('EXISTS: ' if v else 'MISSING: ') + k + (': ' + str(v) if v else ''))
 except FileNotFoundError:
-    print('MISSING: inventories/rhdp-sample-demo/group_vars/all.yml')
+    print('MISSING: ~/.ansible/aap_defaults.yml')
 "
 ```
 
@@ -85,7 +87,7 @@ For each item found, validate it has the right content:
 - **secrets2**: must be non-empty
 - **collections**: must include both `platform` and `controller` subdirectories
 - **SSH key**: must be RSA format
-- **all.yml vars**: `my_vault`, `my_remote_vault`, `my_remote_ssh_pub_key` must be non-empty
+- **aap_defaults.yml**: `my_vault`, `my_remote_vault`, `my_remote_ssh_pub_key` must be non-empty
 
 Skip any section below where the item already exists and is valid. Tell the user what was found before proceeding:
 
@@ -308,38 +310,35 @@ Once they have a URL, validate it as described above.
 
 ## Step 7 — User-Specific Vars
 
-Write the user's identity vars to `inventories/rhdp-sample-demo/group_vars/all.yml`. These are used by `/aap-bootstrap` and `/aap-setup-demo` so you don't have to re-enter them for each environment.
+Write the user's identity vars to `~/.ansible/aap_defaults.yml`. This file persists across sessions and environments — `/aap-bootstrap` reads it automatically when generating a new inventory so these values never need to be re-entered.
 
-Skip any var that already has a non-empty value in `all.yml` (identified in Step 1).
+Skip any var that already has a non-empty value in `~/.ansible/aap_defaults.yml` (identified in Step 1).
 
 ### 7a. Vault credential name
 
 If `my_vault` is missing, ask:
 > "What name should your vault credential have in AAP? This is used as both the credential name and the `my_vault` extra var on your job template. (e.g. `Eric Ames`)"
 
-Write the value to `my_vault` in `all.yml`.
-
 ### 7b. Windows catalog description
 
 If `my_windows_catalog_short_description` is missing, ask:
 > "What is your ServiceNow Windows catalog item short description? Press Enter to accept the default."
-> Default: `Ames AAP Windows AWS Daily Demo`
-
-Write the value (or default) to `my_windows_catalog_short_description` in `all.yml`.
+> Default: `AAP Windows AWS Daily Demo`
 
 ### 7c. Remote vault and SSH key URLs
 
-If `my_remote_vault` or `my_remote_ssh_pub_key` are missing in `all.yml`, write the URLs collected and validated in Steps 5 and 6 to `all.yml` now.
+If `my_remote_vault` or `my_remote_ssh_pub_key` are missing, use the URLs collected and validated in Steps 5 and 6.
 
-### 7d. Write all.yml
+### 7d. Write ~/.ansible/aap_defaults.yml
 
-Use Python to update `inventories/rhdp-sample-demo/group_vars/all.yml` in place, preserving all other keys and comments:
+Use Python to write (or update) `~/.ansible/aap_defaults.yml`, merging with any values already present:
 
 ```bash
 python3 << 'EOF'
-import re
+import yaml, os
 
-path = 'inventories/rhdp-sample-demo/group_vars/all.yml'
+path = os.path.expanduser('~/.ansible/aap_defaults.yml')
+
 updates = {
     'my_vault': '<value from 7a>',
     'my_windows_catalog_short_description': '<value from 7b>',
@@ -347,23 +346,17 @@ updates = {
     'my_remote_ssh_pub_key': '<url from step 5>',
 }
 
-with open(path) as f:
-    content = f.read()
+try:
+    existing = yaml.safe_load(open(path)) or {}
+except FileNotFoundError:
+    existing = {}
 
-for key, value in updates.items():
-    # Replace existing key
-    pattern = rf'^({key}:\s*).*$'
-    replacement = f'{key}: "{value}"'
-    new_content, n = re.subn(pattern, replacement, content, flags=re.MULTILINE)
-    if n == 0:
-        # Append if key not present
-        new_content = content.rstrip('\n') + f'\n{key}: "{value}"\n'
-    content = new_content
+existing.update({k: v for k, v in updates.items() if v})
 
 with open(path, 'w') as f:
-    f.write(content)
+    yaml.dump(existing, f, default_flow_style=False)
 
-print('✅ all.yml updated')
+print('✅ ~/.ansible/aap_defaults.yml written')
 EOF
 ```
 
@@ -400,10 +393,15 @@ test -d ./collections/ansible_collections/ansible/controller && \
   echo "✅ ansible.controller collection — installed" || \
   echo "❌ ansible.controller collection — MISSING"
 
-# SSH key
+# SSH key (check id_rsa; if not found, the user may have a key at a different path)
 test -f ~/.ssh/id_rsa && \
   echo "✅ ~/.ssh/id_rsa — found" || \
-  echo "❌ ~/.ssh/id_rsa — MISSING"
+  echo "⚠️  ~/.ssh/id_rsa — not found (confirm a valid RSA key exists at the path used in Step 5)"
+
+# user defaults
+test -s ~/.ansible/aap_defaults.yml && \
+  echo "✅ ~/.ansible/aap_defaults.yml — found, non-empty" || \
+  echo "❌ ~/.ansible/aap_defaults.yml — missing or empty"
 ```
 
 Also confirm the results from Steps 5–7:


### PR DESCRIPTION
## Summary
- `/aap-first-time` Step 7 now writes user identity vars to `~/.ansible/aap_defaults.yml` instead of `inventories/rhdp-sample-demo/group_vars/all.yml`
- `/aap-bootstrap` preflight and Step 4 read from `~/.ansible/aap_defaults.yml`
- `rhdp-sample-demo/group_vars/all.yml` stays as a clean blank public template — no personal values ever committed
- Multiple users can each have their own `~/.ansible/aap_defaults.yml`; values persist across Claude restarts and new environments automatically

## Why
Previously, user defaults were stored in `rhdp-sample-demo/group_vars/all.yml` which is checked in to the public repo. This caused merge conflicts when pulling updates and made it impossible for multiple users to each have their own defaults without overwriting each other.

## Test plan
- [ ] Run `/aap-first-time` on a fresh setup — confirm Step 7 writes `~/.ansible/aap_defaults.yml`
- [ ] Run `/aap-bootstrap` — confirm preflight reads from `~/.ansible/aap_defaults.yml` and new inventory is populated correctly
- [ ] Confirm `rhdp-sample-demo/group_vars/all.yml` remains blank after first-time setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)