### PR TITLE
fix: write ansible.cfg from template instead of asking user to create it manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - New shared reference file `skills/references/aap-as-code-context.md` with AAP object names, API endpoints, vault URL patterns, and full vault variable table (closes #15)
 
 ### Changed
+- `/aap-first-time` Step 2 now writes `~/.ansible/ansible.cfg` directly after the user provides their Hub token — no manual file creation required; template updated to include `[galaxy]` and `[galaxy_server.community]` sections (closes #24)
 - `/aap-first-time` now collects `my_vault` and `my_windows_catalog_short_description` and writes all four user-specific vars to `inventories/rhdp-sample-demo/group_vars/all.yml` (closes #25)
 - `/aap-bootstrap` and `/aap-setup-demo` now check `inventories/rhdp-sample-demo/group_vars/all.yml` at startup and halt if `my_vault`, `my_remote_vault`, or `my_remote_ssh_pub_key` are empty (closes #25)
 - `/aap-bootstrap` Step 4 now reads user-specific vars from `rhdp-sample-demo/group_vars/all.yml` instead of hardcoding them (closes #25)

--- a/skills/aap-first-time/SKILL.md
+++ b/skills/aap-first-time/SKILL.md
@@ -103,29 +103,42 @@ Skip any section below where the item already exists and is valid. Tell the user
 
 Skip this step if ansible.cfg already exists and contains a valid Hub token.
 
-If missing, show the user exactly what it should look like and ask them to create it:
+If missing or invalid, prompt:
+> "Paste your Automation Hub API token. Get it at: https://console.redhat.com/ansible/automation-hub/token"
+
+Once the user provides the token, write `~/.ansible/ansible.cfg` directly using the Write tool with this exact template, substituting the token into both `rh_certified` and `rh_validated`:
 
 ```ini
 [defaults]
 collections_paths = ./collections
 
+[galaxy]
+server_list = rh_certified, rh_validated, community
+
 [galaxy_server.rh_certified]
 url=https://console.redhat.com/api/automation-hub/content/published/
 auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
-token=PASTE_YOUR_TOKEN_HERE
+token=<USER_TOKEN>
 
 [galaxy_server.rh_validated]
 url=https://console.redhat.com/api/automation-hub/content/validated/
 auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
-token=PASTE_YOUR_TOKEN_HERE
+token=<USER_TOKEN>
+
+[galaxy_server.community]
+url=https://galaxy.ansible.com/
 ```
 
-Then prompt:
-> "Paste your Automation Hub API token. Get it at: https://console.redhat.com/ansible/automation-hub/token"
+After writing, set permissions and validate:
 
-Write the token into both `[galaxy_server.rh_certified]` and `[galaxy_server.rh_validated]` token fields. Validate the written value is not the placeholder string `PASTE_YOUR_TOKEN_HERE`.
+```bash
+chmod 600 ~/.ansible/ansible.cfg
+grep -v "PASTE_YOUR_TOKEN_HERE" ~/.ansible/ansible.cfg | grep -q "token=" && \
+  echo "✅ ~/.ansible/ansible.cfg written with Hub token" || \
+  echo "❌ token not set correctly"
+```
 
-If ansible.cfg exists but the token is missing or placeholder, ask the user to paste their token and update it in place.
+If ansible.cfg exists but the token is missing or placeholder, ask the user to paste their token and rewrite the file using the same template and steps above.
 
 ## Step 3 — secrets2 Setup
 


### PR DESCRIPTION
## Summary

- Step 2 of `/aap-first-time` now writes `~/.ansible/ansible.cfg` directly after the user pastes their Hub token — no manual file creation required
- Template updated to include the missing `[galaxy]` and `[galaxy_server.community]` sections
- File permissions set to `600` after writing
- Post-write validation confirms token is not the placeholder string

Closes #24

## Test plan

- [ ] Run `/aap-first-time` on a machine without `~/.ansible/ansible.cfg`
- [ ] Paste a Hub token when prompted — confirm Claude writes the file directly
- [ ] Confirm all four sections are present in the written file
- [ ] Confirm `ls -l ~/.ansible/ansible.cfg` shows `600` permissions
- [ ] Run again with the file already present and valid — confirm Step 2 is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)